### PR TITLE
Feature/asdf in pytest workflow

### DIFF
--- a/.github/workflows/reusable-python-uv-pytest.yml
+++ b/.github/workflows/reusable-python-uv-pytest.yml
@@ -84,8 +84,10 @@ jobs:
         chmod +x ~/.local/bin/repo
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         set -x
-        git config user.name "GitHub Actions"
-        git config user.email "noreply@launch.nttdata.com"
+        export GIT_AUTHOR_NAME="GitHub Actions"
+        export GIT_COMMITTER_NAME="GitHub Actions"
+        export GIT_AUTHOR_EMAIL="noreply@launch.nttdata.com"
+        export GIT_COMMITTER_EMAIL="noreply@launch.nttdata.com"
         export AWS_REGION=${{ inputs.lcaf-aws-region }}
 
     - name: Ruff check

--- a/.github/workflows/reusable-python-uv-pytest.yml
+++ b/.github/workflows/reusable-python-uv-pytest.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Cache asdf tools
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684
       id: save-cache
-      if: inputs.asdf-install == 'true' && steps.cache.outputs.cache-hit != 'true'
+      if: ${{ inputs.asdf-install == 'true' && steps.cache.outputs.cache-hit != 'true' }}
       with:
         path: ~/.asdf
         key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
@@ -84,10 +84,8 @@ jobs:
         chmod +x ~/.local/bin/repo
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         set -x
-        export GIT_AUTHOR_NAME="GitHub Actions"
-        export GIT_COMMITTER_NAME="GitHub Actions"
-        export GIT_AUTHOR_EMAIL="noreply@launch.nttdata.com"
-        export GIT_COMMITTER_EMAIL="noreply@launch.nttdata.com"
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "noreply@launch.nttdata.com"
         export AWS_REGION=${{ inputs.lcaf-aws-region }}
 
     - name: Ruff check

--- a/.github/workflows/reusable-python-uv-pytest.yml
+++ b/.github/workflows/reusable-python-uv-pytest.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Cache asdf tools
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684
       id: save-cache
-      if: ${{ inputs.asdf-install == 'true' && steps.cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.asdf-install && steps.cache.outputs.cache-hit != 'true' }}
       with:
         path: ~/.asdf
         key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}

--- a/.github/workflows/reusable-python-uv-pytest.yml
+++ b/.github/workflows/reusable-python-uv-pytest.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: '3.11'
+      asdf-install:
+        description: 'Whether to install supplementary tools from .tool-versions'
+        required: false
+        type: boolean
+        default: true
       run-ruff:
         description: 'Run Ruff for linting and formatting checks'
         required: false
@@ -33,6 +38,26 @@ jobs:
         python-version: [ "${{ inputs.python-version }}" ]
     steps:
     - uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
+
+    - name: Restore cached asdf tools
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
+      if: ${{ inputs.asdf-install }}
+      id: cache
+      with:
+        path: ~/.asdf
+        key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
+
+    - name: asdf install
+      if: ${{ inputs.asdf-install }}
+      uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 
+
+    - name: Cache asdf tools
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684
+      id: save-cache
+      if: inputs.asdf-install == 'true' && steps.cache.outputs.cache-hit != 'true'
+      with:
+        path: ~/.asdf
+        key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc

--- a/.github/workflows/reusable-python-uv-pytest.yml
+++ b/.github/workflows/reusable-python-uv-pytest.yml
@@ -81,8 +81,7 @@ jobs:
         set -x
         git config user.name "GitHub Actions"
         git config user.email "noreply@launch.nttdata.com"
-        export AWS_REGION=${{ env.TERRAFORM_CHECK_AWS_REGION }}
-        make configure
+        export AWS_REGION=${{ env.TERRAFORM_CHECK_AWS_REGION || 'us-east-2' }}
 
     - name: Ruff check
       if: ${{ inputs.run-ruff }}

--- a/.github/workflows/reusable-python-uv-pytest.yml
+++ b/.github/workflows/reusable-python-uv-pytest.yml
@@ -13,11 +13,16 @@ on:
         required: false
         type: boolean
         default: true
-      legacy-makefile-setup:
-        description: 'Whether to set the environment up for the legacy LCAF Makefile'
+      lcaf-makefile-setup:
+        description: 'Whether to set the environment up for the LCAF Makefile'
         required: false
         type: boolean
         default: false
+      lcaf-aws-region:
+        description: 'AWS region to use for LCAF Makefile setup. Ignored if lcaf-makefile-setup is false.'
+        required: false
+        type: string
+        default: 'us-east-2'
       run-ruff:
         description: 'Run Ruff for linting and formatting checks'
         required: false
@@ -70,8 +75,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Repository for Makefile
-      if: ${{ inputs.legacy-makefile-setup }}
-      # Ensure the 'repo' tool is installed, set up git to make the Makefile happy, and then configure to clone LCAF.
+      if: ${{ inputs.lcaf-makefile-setup }}
+      # Ensure the 'repo' tool is installed, set up git to make the Makefile happy
       shell: bash
       run: |
         mkdir -p ~/.local/bin
@@ -81,7 +86,7 @@ jobs:
         set -x
         git config user.name "GitHub Actions"
         git config user.email "noreply@launch.nttdata.com"
-        export AWS_REGION=${{ env.TERRAFORM_CHECK_AWS_REGION || 'us-east-2' }}
+        export AWS_REGION=${{ inputs.lcaf-aws-region }}
 
     - name: Ruff check
       if: ${{ inputs.run-ruff }}

--- a/.github/workflows/reusable-python-uv-pytest.yml
+++ b/.github/workflows/reusable-python-uv-pytest.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: true
+      legacy-makefile-setup:
+        description: 'Whether to set the environment up for the legacy LCAF Makefile'
+        required: false
+        type: boolean
+        default: false
       run-ruff:
         description: 'Run Ruff for linting and formatting checks'
         required: false
@@ -63,6 +68,21 @@ jobs:
       uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Setup Repository for Makefile
+      if: ${{ inputs.legacy-makefile-setup }}
+      # Ensure the 'repo' tool is installed, set up git to make the Makefile happy, and then configure to clone LCAF.
+      shell: bash
+      run: |
+        mkdir -p ~/.local/bin
+        curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.local/bin/repo
+        chmod +x ~/.local/bin/repo
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        set -x
+        git config user.name "GitHub Actions"
+        git config user.email "noreply@launch.nttdata.com"
+        export AWS_REGION=${{ env.TERRAFORM_CHECK_AWS_REGION }}
+        make configure
 
     - name: Ruff check
       if: ${{ inputs.run-ruff }}


### PR DESCRIPTION
Adds support for: 

- Installation of supplementary tools through asdf's `.tool-versions` file,
- Setting up the test environment such that pytest can invoke `make configure` and other LCAF commands

By default, we'll try to install anything in the .tool-versions file prior to executing tests. Setting up the environment for LCAF commands is defaulted false and must be explicitly enabled, as most of our Python packages won't require this step; it is specific to test runs that depend on the LCAF Makefile / repo synchronization behaviors. 