### PR TITLE
Add reusable workflow for Azure TF modules

### DIFF
--- a/.github/workflows/reusable-terraform-check-azure.yml
+++ b/.github/workflows/reusable-terraform-check-azure.yml
@@ -1,4 +1,4 @@
-name: Check AWS Terraform Code
+name: Check Azure Terraform Code
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check:
-    name: "Check AWS Terraform Code"
+    name: "Check Azure Terraform Code"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-terraform-check-azure.yml
+++ b/.github/workflows/reusable-terraform-check-azure.yml
@@ -1,0 +1,67 @@
+name: Check AWS Terraform Code
+
+on:
+  workflow_call:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check:
+    name: "Check AWS Terraform Code"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
+
+      - name: Setup asdf
+        # We use the 'setup' variant of this action, because we have some custom behavior in 
+        # our .tool-versions file and Makefile to install plugins from outside the default registry.
+        uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302
+
+      - uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809
+        # If we've cached the asdf tools, restore them based on the hash of the .tool-versions file.
+        name: Restore cached asdf tools
+        id: cache
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
+
+      - name: Setup Repository for Checks
+        # Ensure the 'repo' tool is installed, set up git to make the Makefile happy, and then configure to clone LCAF.
+        shell: bash
+        run: |
+          mkdir -p ~/.local/bin
+          curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.local/bin/repo
+          chmod +x ~/.local/bin/repo
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          set -x
+          git config user.name "GitHub Actions"
+          git config user.email "noreply@launch.nttdata.com"
+          export ARM_SUBSCRIPTION_ID=${{ secrets.TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID }}
+          make configure
+
+      - uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809
+        # If we didn't restore the asdf tools, save them based on the hash of the .tool-versions file.
+        id: save-cache
+        name: Cache asdf tools
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
+
+      - name: "make lint"
+        run: |
+          make lint
+
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        with:
+          client-id: ${{ secrets.TERRAFORM_CHECK_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.TERRAFORM_CHECK_AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID }}
+
+      - name: "make test"
+        run: |
+          make test

--- a/docs/reusable-terraform-check-aws.md
+++ b/docs/reusable-terraform-check-aws.md
@@ -30,7 +30,6 @@ jobs:
     with:
       assume_role_arn: "arn:aws:iam::123456789012:role/my-assumed-role"
       region: "us-east-2"
-    secrets: inherit
 
 ```
 

--- a/docs/reusable-terraform-check-azure.md
+++ b/docs/reusable-terraform-check-azure.md
@@ -1,0 +1,39 @@
+# Check a Terraform Module in Azure
+
+Performs a series of checks of a Terraform module, including deploying the example modules to Azure.
+
+This action wraps both the `make lint` and `make test` targets in the Makefile.
+
+## Usage
+
+To check the Terraform code on a PR:
+
+```yaml
+name: Check Azure Terraform Code
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches: [ main ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check:
+    name: "Check Azure Terraform Code"
+    permissions:
+      contents: read
+      id-token: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-azure.yml@ref
+    secrets: inherit
+    
+    # Alternately, pass the following secrets:
+    #   TERRAFORM_CHECK_AZURE_CLIENT_ID: ${{ secrets.your_azure_client_id_secret }}
+    #   TERRAFORM_CHECK_AZURE_TENANT_ID: ${{ secrets.your_azure_tenant_id_secret }}
+    #   TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID: ${{ secrets.your_azure_subscription_id_secret }}
+
+```
+
+Be sure you replace `ref` with an appropriate ref to this repository. For more information on OIDC setup for Azure, see the [azure/login action documentation](https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended).

--- a/docs/reusable-terraform-check-azure.md
+++ b/docs/reusable-terraform-check-azure.md
@@ -27,7 +27,7 @@ jobs:
       contents: read
       id-token: write
     uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-azure.yml@ref
-    secrets: inherit
+    secrets: inherit # pragma: allowlist secret
     
     # Alternately, pass the following secrets:
     #   TERRAFORM_CHECK_AZURE_CLIENT_ID: ${{ secrets.your_azure_client_id_secret }}


### PR DESCRIPTION
Adds an equivalent to the TF workflow for AWS that executes `make lint` and `make check` against the Terraform code in our standard layout.

An example run against this branch can be found here: https://github.com/launchbynttdata/tf-azurerm-module_primitive-postgresql_firewall_rule/actions/runs/17168143104/job/48712750228?pr=1

This utilizes OIDC to create a short-lived connection between a workflow and our Azure sandbox environment. For repositories in the `launchbynttdata` organization, secrets are already configured at the organization level for use by any of our Azure TF repositories, simply inherit secrets while calling this workflow.