### PR TITLE
fix: remove labels applied by dependabot in branch-based PR labeling workflow

### DIFF
--- a/.github/actions/remove-dependabot-labels/README.md
+++ b/.github/actions/remove-dependabot-labels/README.md
@@ -1,0 +1,67 @@
+# Remove Dependabot Labels Action
+
+When Dependabot creates pull requests, it often applies ecosystem-specific labels (such as `go`, `javascript`, `python`, `docker`, etc.) in addition to the `dependencies` label. These labels can interfere with branch-based labeling strategies used by tools like [release-drafter](https://github.com/release-drafter/release-drafter).
+
+This action removes labels that were applied by Dependabot while preserving specified labels (by default, only `dependencies`). Labels applied by other users or bots are not affected.
+
+## Behavior
+
+This action will:
+1. Query the GitHub Issues Events API to identify labels applied specifically by `dependabot[bot]`
+2. Remove all Dependabot-applied labels except those in the preserve list
+3. Leave labels applied by other users or bots untouched
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `pr_number` | The pull request number to process | No | `${{ github.event.pull_request.number }}` |
+| `github_token` | GitHub token for API access | No | `${{ github.token }}` |
+| `preserve_labels` | Comma-separated list of labels to preserve (not remove even if applied by Dependabot) | No | `dependencies` |
+
+## Usage
+
+### Basic Usage
+
+When used in a `pull_request` event workflow, all inputs are optional:
+
+```yaml
+jobs:
+  your-job:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove Dependabot Labels
+        uses: launchbynttdata/launch-workflows/.github/actions/remove-dependabot-labels@main
+```
+
+### Preserve Additional Labels
+
+To preserve additional Dependabot labels beyond `dependencies`:
+
+```yaml
+- name: Remove Dependabot Labels
+  uses: launchbynttdata/launch-workflows/.github/actions/remove-dependabot-labels@main
+  with:
+    preserve_labels: "dependencies,security"
+```
+
+### Explicit PR Number
+
+If running outside a `pull_request` event context, provide the PR number explicitly:
+
+```yaml
+- name: Remove Dependabot Labels
+  uses: launchbynttdata/launch-workflows/.github/actions/remove-dependabot-labels@main
+  with:
+    pr_number: "123"
+```
+
+## Required Permissions
+
+This action requires the following permissions:
+- `pull-requests: write` - To remove labels from pull requests

--- a/.github/actions/remove-dependabot-labels/action.yml
+++ b/.github/actions/remove-dependabot-labels/action.yml
@@ -1,0 +1,104 @@
+name: "Remove Dependabot Labels"
+description: "Remove labels applied by Dependabot from a pull request, except for the specified label(s) to preserve."
+inputs:
+  pr_number:
+    description: "The pull request number to process. Defaults to the PR number from the event context."
+    required: false
+    default: ${{ github.event.pull_request.number }}
+  github_token:
+    description: "GitHub token for API access. Defaults to the automatic GITHUB_TOKEN."
+    required: false
+    default: ${{ github.token }}
+  preserve_labels:
+    description: "Comma-separated list of Dependabot labels to preserve (default: dependencies)"
+    required: false
+    default: "dependencies"
+runs:
+  using: "composite"
+  steps:
+    - name: Remove Dependabot Labels
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        PRESERVE_LABELS: ${{ inputs.preserve_labels }}
+      run: |
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "Error: PR number not provided and not available in the event context."
+          echo "Please provide a pr_number input or run this action from a pull_request event."
+          exit 1
+        fi
+
+        echo "Processing PR #${PR_NUMBER} to remove Dependabot-applied labels..."
+
+        # Convert preserve_labels to an array for easy lookup
+        IFS=',' read -ra PRESERVE_ARRAY <<< "$PRESERVE_LABELS"
+
+        # Function to check if a label should be preserved
+        should_preserve() {
+          local label="$1"
+          for preserve in "${PRESERVE_ARRAY[@]}"; do
+            # Trim whitespace
+            preserve=$(echo "$preserve" | xargs)
+            if [[ "$label" == "$preserve" ]]; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
+        # Get all label events for this PR (labeled events only, applied by dependabot)
+        # The issues events API works for PRs since PRs are issues
+        echo "Fetching label events..."
+        LABEL_EVENTS=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/events" \
+          --paginate \
+          --jq '[.[] | select(.event == "labeled" and (.actor.login == "dependabot[bot]" or .actor.type == "Bot" and .actor.login == "dependabot")) | .label.name] | unique')
+
+        if [[ "$LABEL_EVENTS" == "[]" ]] || [[ -z "$LABEL_EVENTS" ]]; then
+          echo "No labels applied by Dependabot found."
+          exit 0
+        fi
+
+        echo "Labels applied by Dependabot: $LABEL_EVENTS"
+
+        # Get current labels on the PR to ensure we only try to remove labels that exist
+        CURRENT_LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '[.labels[].name]')
+        echo "Current labels on PR: $CURRENT_LABELS"
+
+        # Process each label applied by Dependabot
+        LABELS_TO_REMOVE=()
+        while IFS= read -r label; do
+          # Skip empty lines
+          [[ -z "$label" ]] && continue
+          
+          # Check if this label should be preserved
+          if should_preserve "$label"; then
+            echo "Preserving label: $label"
+            continue
+          fi
+
+          # Check if the label is still on the PR
+          if echo "$CURRENT_LABELS" | jq -e --arg label "$label" 'index($label) != null' > /dev/null 2>&1; then
+            LABELS_TO_REMOVE+=("$label")
+          else
+            echo "Label '$label' is no longer on the PR, skipping."
+          fi
+        done < <(echo "$LABEL_EVENTS" | jq -r '.[]')
+
+        # Remove the labels
+        if [[ ${#LABELS_TO_REMOVE[@]} -eq 0 ]]; then
+          echo "No labels to remove."
+          exit 0
+        fi
+
+        echo "Labels to remove: ${LABELS_TO_REMOVE[*]}"
+        for label in "${LABELS_TO_REMOVE[@]}"; do
+          echo "Removing label: $label"
+          # URL encode the label name for the API call
+          ENCODED_LABEL=$(printf '%s' "$label" | jq -sRr @uri)
+          gh api -X DELETE "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels/${ENCODED_LABEL}" || {
+            echo "Warning: Failed to remove label '$label'. It may have already been removed."
+          }
+        done
+
+        echo "Done processing Dependabot labels."

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
+
+multi-ecosystem-groups:
+  workflows:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "workflows"
+    patterns: ["*"]

--- a/.github/workflows/reusable-pr-label-by-branch.yml
+++ b/.github/workflows/reusable-pr-label-by-branch.yml
@@ -2,7 +2,17 @@ name: Label Pull Request by Branch
 
 on:
   workflow_call:
-
+    inputs:
+      remove_dependabot_labels:
+        description: "Whether to remove labels applied by Dependabot. If true, the workflow will attempt to remove any labels applied by Dependabot on the pull request, except for those specified in preserve_dependabot_labels."
+        required: false
+        default: true
+        type: boolean
+      preserve_dependabot_labels:
+        description: "Comma-separated list of Dependabot labels to preserve when remove_dependabot_labels is true. Default: dependencies"
+        required: false
+        default: dependencies
+        type: string
 jobs:
   configure-labels:
     name: Configure Labels
@@ -20,9 +30,10 @@ jobs:
           jq -e 'if map(select(.name | contains ("patch"))) == [] then null else "Label patch exists" end' labels.json || gh label create patch --color "006b75"
           jq -e 'if map(select(.name | contains ("minor"))) == [] then null else "Label minor exists" end' labels.json || gh label create minor --color "fbca04"
           jq -e 'if map(select(.name | contains ("major"))) == [] then null else "Label major exists" end' labels.json || gh label create major --color "b60205"
+          jq -e 'if map(select(.name | contains ("dependencies"))) == [] then null else "Label dependencies exists" end' labels.json || gh label create dependencies --color "0366d6"
   label-pr:
     name: Label Pull Request
-    needs: [ configure-labels ]
+    needs: [configure-labels]
     permissions:
       contents: read
       pull-requests: write
@@ -63,8 +74,15 @@ jobs:
             # Not the first PR, so we can attempt to auto-label it.
             echo "auto_label=true" >> $GITHUB_OUTPUT
           fi
-          
+
           rm first-time-comment.md
+
+      - uses: launchbynttdata/launch-workflows/.github/actions/remove-dependabot-labels@0.14.2
+        if: ${{ inputs.remove_dependabot_labels }}
+        id: remove-dependabot-labels
+        with:
+          preserve_labels: ${{ inputs.preserve_dependabot_labels }}
+
       - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97
         if: steps.prerequisite-check.outputs.auto_label == 'true'
         id: autolabel

--- a/docs/reusable-pr-label-by-branch.md
+++ b/docs/reusable-pr-label-by-branch.md
@@ -29,8 +29,39 @@ jobs:
       pull-requests: write
     uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@ref
     secrets: inherit
-
-
 ```
 
 Be sure you replace `ref` with an appropriate ref to this repository.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `remove_dependabot_labels` | Whether to remove labels applied by Dependabot. If true, the workflow will attempt to remove any labels applied by Dependabot on the pull request, except for those specified in `preserve_dependabot_labels`. | No | `true` |
+| `preserve_dependabot_labels` | Comma-separated list of Dependabot labels to preserve when `remove_dependabot_labels` is true. | No | `dependencies` |
+
+### Dependabot Label Handling
+
+By default, this workflow removes labels that Dependabot applies to pull requests (such as `go`, `javascript`, `python`, etc.) while preserving the `dependencies` label. This prevents Dependabot's ecosystem-specific labels from interfering with the branch-based labeling strategy.
+
+To disable this behavior:
+
+```yaml
+jobs:
+  check:
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@ref
+    with:
+      remove_dependabot_labels: false
+    secrets: inherit
+```
+
+To preserve additional Dependabot labels:
+
+```yaml
+jobs:
+  check:
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@ref
+    with:
+      preserve_dependabot_labels: "dependencies,security"
+    secrets: inherit
+```


### PR DESCRIPTION
Dependabot's labeling configuration leaves some major things to be desired. When it makes PRs to our repos, it's including labels that correspond to our semantic version bumps from the dependencies it's updating. This causes a problem: an update to a dependency's major version does not correspond to a bump of our module's major version, in fact, it's the opposite: all dependency updates to our modules are patch version updates because they do not adjust the API surface of a given module.

The configuration you can provide to disable labeling entirely in Dependabot does not work and has been broken for some time. I see community issues that were raised multiple years ago around this issue being unsatisfactorily resolved, or in some cases, they appear to be ignored. I don't think we can bank on Dependabot fixing this behavior any time soon.

As a workaround, our workflow that labels pull requests now has configuration to strip labels applied by Dependabot. We want to utilize the `dependencies` tag, so there is a way to configure the workflow / action to persist desired tags. I've configured these inputs such that the default values will be appropriate for the bulk of our use cases and shouldn't require any special configuration.

<img width="858" height="211" alt="image" src="https://github.com/user-attachments/assets/99a4ca74-4e12-424e-a0aa-ce1cdd75bce5" />

There's no need to apply this action to the conventional commits workflow; it is configured to strip all labels regardless of who applied them when it runs, so that stray scope labels are appropriately handled when the PR's title goes from one scope to another (or none).

Additionally, this PR sets up this repository's Dependabot configuration so that updates are grouped, rather than opening individual PRs for each dependency.