### PR TITLE
feat: add consolidated TF module check workflow

### DIFF
--- a/.github/actions/update-status-check/README.md
+++ b/.github/actions/update-status-check/README.md
@@ -1,0 +1,111 @@
+# Update Status Check Action
+
+GitHub's [Commit Status API](https://docs.github.com/en/rest/commits/statuses) allows workflows to report the state of a check back to a specific commit SHA. This is useful for surfacing the outcome of external processes, gating merges, or providing richer context in pull requests beyond what a workflow run alone provides.
+
+This action wraps the Commit Status API with a simple interface: provide a check name and a status, and we handle the API call.
+
+## Behavior
+
+This action will:
+1. Validate that the provided `status` is one of the accepted values (`error`, `failure`, `pending`, `success`)
+2. Call the GitHub Commit Status API to create or update the named status check on the specified commit SHA
+3. Optionally attach a human-readable description and a target URL to the status
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `check_name` | The name (context) of the status check to create or update | Yes | — |
+| `status` | The state to set. One of: `error`, `failure`, `pending`, `success` | Yes | — |
+| `sha` | The commit SHA to attach the status check to | No | `${{ github.sha }}` |
+| `description` | A short human-readable description of the status | No | `""` |
+| `target_url` | A URL to associate with the status (e.g. a link to a build log) | No | `""` |
+| `github_token` | GitHub token for API access | No | `${{ github.token }}` |
+
+## Usage
+
+### Basic Usage
+
+Mark a status check as successful on the current commit:
+
+```yaml
+jobs:
+  your-job:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set status check to success
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@main
+        with:
+          check_name: "my-check"
+          status: "success"
+```
+
+### With Description and Target URL
+
+Provide additional context visible in the GitHub UI:
+
+```yaml
+- name: Set status check to failure
+  uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@main
+  with:
+    check_name: "security-scan"
+    status: "failure"
+    description: "Vulnerabilities were detected."
+    target_url: "https://example.com/scan-results/123"
+```
+
+### Marking a Check as Pending Before a Long-Running Step
+
+Use `pending` to signal that a check is in progress, then update it on completion:
+
+```yaml
+- name: Mark check as pending
+  uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@main
+  with:
+    check_name: "integration-tests"
+    status: "pending"
+    description: "Integration tests are running..."
+
+- name: Run integration tests
+  run: make test-integration
+
+- name: Mark check as success
+  if: success()
+  uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@main
+  with:
+    check_name: "integration-tests"
+    status: "success"
+    description: "All integration tests passed."
+
+- name: Mark check as failure
+  if: failure()
+  uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@main
+  with:
+    check_name: "integration-tests"
+    status: "failure"
+    description: "One or more integration tests failed."
+```
+
+### Targeting a Specific Commit SHA
+
+Override the default SHA to set a status on a commit other than the one that triggered the workflow:
+
+```yaml
+- name: Set status on a specific commit
+  uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@main
+  with:
+    check_name: "my-check"
+    status: "success"
+    sha: "abc1234def5678"
+```
+
+## Required Permissions
+
+This action requires the following permission on the workflow job:
+
+```yaml
+permissions:
+  statuses: write
+```

--- a/.github/actions/update-status-check/action.yml
+++ b/.github/actions/update-status-check/action.yml
@@ -1,0 +1,65 @@
+name: "Update Status Check"
+description: "Use the GitHub Commit Status API to create or update a status check on a commit."
+inputs:
+  check_name:
+    description: "The name (context) of the status check to create or update."
+    required: true
+  status:
+    description: "The state to set on the status check. Must be one of: error, failure, pending, success."
+    required: true
+  sha:
+    description: "The commit SHA to attach the status check to. Defaults to the SHA that triggered the workflow."
+    required: false
+    default: ${{ github.sha }}
+  description:
+    description: "A short human-readable description of the status check."
+    required: false
+    default: ""
+  target_url:
+    description: "A URL to associate with the status check, typically a link to relevant build or run output."
+    required: false
+    default: ""
+  github_token:
+    description: "GitHub token for API access. Defaults to the automatic GITHUB_TOKEN."
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - name: Update Status Check
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        CHECK_NAME: ${{ inputs.check_name }}
+        STATUS: ${{ inputs.status }}
+        SHA: ${{ inputs.sha }}
+        DESCRIPTION: ${{ inputs.description }}
+        TARGET_URL: ${{ inputs.target_url }}
+      run: |
+        VALID_STATES=("error" "failure" "pending" "success")
+        VALID=false
+        for state in "${VALID_STATES[@]}"; do
+          if [[ "$STATUS" == "$state" ]]; then
+            VALID=true
+            break
+          fi
+        done
+
+        if [[ "$VALID" != "true" ]]; then
+          echo "Error: Invalid status '${STATUS}'. Must be one of: error, failure, pending, success."
+          exit 1
+        fi
+
+        echo "Setting status check '${CHECK_NAME}' to '${STATUS}' on commit ${SHA}..."
+
+        PAYLOAD=$(jq -n \
+          --arg state "$STATUS" \
+          --arg context "$CHECK_NAME" \
+          --arg description "$DESCRIPTION" \
+          --arg target_url "$TARGET_URL" \
+          '{state: $state, context: $context, description: $description, target_url: $target_url}')
+
+        gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
+          --input - <<< "$PAYLOAD"
+
+        echo "Status check '${CHECK_NAME}' successfully set to '${STATUS}'."

--- a/.github/workflows/reusable-terraform-check-aws.yml
+++ b/.github/workflows/reusable-terraform-check-aws.yml
@@ -4,18 +4,19 @@ on:
   workflow_call:
     inputs:
       assume_role_arn:
-        description: 'ARN of the role to assume prior to Terragrunt invocation. Terragrunt may use this role to assume other roles if configured to do so.'
+        description: "ARN of the role to assume prior to Terragrunt invocation. Terragrunt may use this role to assume other roles if configured to do so."
         required: true
         type: string
       region:
-        description: 'Region within the environment (e.g. us-east-1) to deploy'
-        default: 'us-east-2'
+        description: "Region within the environment (e.g. us-east-1) to deploy"
+        default: "us-east-2"
         required: true
         type: string
 
 permissions:
   id-token: write
   contents: read
+  statuses: write
 
 jobs:
   check:
@@ -26,7 +27,7 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Setup asdf
-        # We use the 'setup' variant of this action, because we have some custom behavior in 
+        # We use the 'setup' variant of this action, because we have some custom behavior in
         # our .tool-versions file and Makefile to install plugins from outside the default registry.
         uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47
 
@@ -61,9 +62,25 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
-      - name: "make lint"
+      - name: "Set Terraform Lint status to pending"
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Lint"
+          status: "pending"
+          description: "Terraform lint check is running..."
+
+      - id: lint
+        name: "make lint"
         run: |
           make lint
+
+      - name: "Update Terraform Lint status"
+        if: always() && steps.lint.outcome != 'skipped'
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Lint"
+          status: ${{ steps.lint.outcome == 'success' && 'success' || steps.lint.outcome == 'failure' && 'failure' || 'error' }}
+          description: "Terraform lint ${{ steps.lint.outcome }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
@@ -86,6 +103,22 @@ jobs:
           # Fixup examples' provider.tf by dropping references to the profile, so that we can use the default profile.
           find examples -type f -name "provider.tf" -mindepth 2 -maxdepth 2 -exec bash -c 'grep -vE "profile\s=" "$1" > $1.tmp && mv $1.tmp $1' bash {} \;
 
-      - name: "make test"
+      - name: "Set Terraform Tests status to pending"
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Tests"
+          status: "pending"
+          description: "Terraform tests are running..."
+
+      - id: test
+        name: "make test"
         run: |
           make test
+
+      - name: "Update Terraform Tests status"
+        if: always() && steps.test.outcome != 'skipped'
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Tests"
+          status: ${{ steps.test.outcome == 'success' && 'success' || steps.test.outcome == 'failure' && 'failure' || 'error' }}
+          description: "Terraform tests ${{ steps.test.outcome }}"

--- a/.github/workflows/reusable-terraform-check-azure.yml
+++ b/.github/workflows/reusable-terraform-check-azure.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  statuses: write
 
 jobs:
   check:
@@ -58,9 +59,25 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
-      - name: "make lint"
+      - name: "Set Terraform Lint status to pending"
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Lint"
+          status: "pending"
+          description: "Terraform lint check is running..."
+
+      - id: lint
+        name: "make lint"
         run: |
           make lint
+
+      - name: "Update Terraform Lint status"
+        if: always() && steps.lint.outcome != 'skipped'
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Lint"
+          status: ${{ steps.lint.outcome == 'success' && 'success' || steps.lint.outcome == 'failure' && 'failure' || 'error' }}
+          description: "Terraform lint ${{ steps.lint.outcome }}"
 
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
@@ -69,6 +86,22 @@ jobs:
           tenant-id: ${{ secrets.TERRAFORM_CHECK_AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID }}
 
-      - name: "make test"
+      - name: "Set Terraform Tests status to pending"
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Tests"
+          status: "pending"
+          description: "Terraform tests are running..."
+
+      - id: test
+        name: "make test"
         run: |
           make test
+
+      - name: "Update Terraform Tests status"
+        if: always() && steps.test.outcome != 'skipped'
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Tests"
+          status: ${{ steps.test.outcome == 'success' && 'success' || steps.test.outcome == 'failure' && 'failure' || 'error' }}
+          description: "Terraform tests ${{ steps.test.outcome }}"

--- a/.github/workflows/reusable-terraform-check.yml
+++ b/.github/workflows/reusable-terraform-check.yml
@@ -29,6 +29,7 @@ on:
 permissions:
   contents: read
   id-token: write # Required for various OIDC auth flows.
+  statuses: write
 
 jobs:
   validate-inputs:
@@ -124,10 +125,27 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
+      - id: set-lint-pending
+        name: "Set Terraform Lint status to pending"
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Lint"
+          status: "pending"
+          description: "Terraform lint check is running..."
+
       - id: lint
         name: "make lint"
         run: |
           make lint
+
+      - id: update-lint-status
+        name: "Update Terraform Lint status"
+        if: always() && steps.lint.outcome != 'skipped'
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Lint"
+          status: ${{ steps.lint.outcome == 'success' && 'success' || steps.lint.outcome == 'failure' && 'failure' || 'error' }}
+          description: "Terraform lint ${{ steps.lint.outcome }}"
 
       - id: configure-aws-credentials
         name: Configure AWS credentials
@@ -163,7 +181,24 @@ jobs:
           tenant-id: ${{ secrets.TERRAFORM_CHECK_AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID }}
 
+      - id: set-tests-pending
+        name: "Set Terraform Tests status to pending"
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Tests"
+          status: "pending"
+          description: "Terraform tests are running..."
+
       - id: test
         name: "make test"
         run: |
           make test
+
+      - id: update-tests-status
+        name: "Update Terraform Tests status"
+        if: always() && steps.test.outcome != 'skipped'
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@feat/unify-terraform-check-workflows
+        with:
+          check_name: "Terraform Tests"
+          status: ${{ steps.test.outcome == 'success' && 'success' || steps.test.outcome == 'failure' && 'failure' || 'error' }}
+          description: "Terraform tests ${{ steps.test.outcome }}"

--- a/.github/workflows/reusable-terraform-check.yml
+++ b/.github/workflows/reusable-terraform-check.yml
@@ -1,0 +1,169 @@
+name: Check Terraform Code
+
+on:
+  workflow_call:
+    inputs:
+      auth_method:
+        description: 'Authentication method to use for Terraform checks. Valid values are "none", "aws", and "azure".'
+        required: true
+        type: string
+      assume_role_arn:
+        description: "ARN of the role to assume when running tests and creating test resources. Required if auth_method is 'aws', ignored otherwise. Defaults to the value of the TERRAFORM_CHECK_AWS_ASSUME_ROLE_ARN variable."
+        required: false
+        type: string
+        default: "${{ vars.TERRAFORM_CHECK_AWS_ASSUME_ROLE_ARN }}"
+      region:
+        description: "AWS region to deploy when running tests and creating resources. Required if auth_method is 'aws', ignored otherwise. Defaults to the value of the TERRAFORM_CHECK_AWS_REGION variable."
+        default: "${{ vars.TERRAFORM_CHECK_AWS_REGION }}"
+        required: false
+        type: string
+    secrets:
+      # If using Azure authentication, these secrets must be provided. They are not required for the workflow itself to allow reuse in non-Azure contexts.
+      TERRAFORM_CHECK_AZURE_CLIENT_ID:
+        required: false
+      TERRAFORM_CHECK_AZURE_TENANT_ID:
+        required: false
+      TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write # Required for various OIDC auth flows.
+
+jobs:
+  validate-inputs:
+    name: "Validate Inputs"
+    runs-on: ubuntu-latest
+    outputs:
+      auth_method: ${{ steps.validate.outputs.auth_method }}
+    steps:
+      - name: Validate inputs and secrets
+        id: validate
+        shell: bash
+        run: |
+          if [[ "${{ inputs.auth_method }}" != "none" && "${{ inputs.auth_method }}" != "aws" && "${{ inputs.auth_method }}" != "azure" ]]; then
+            echo "Error: Invalid auth_method input '${{ inputs.auth_method }}'. Valid values are 'none', 'aws', and 'azure'."
+            exit 1
+          fi
+
+          if [[ "${{ inputs.auth_method }}" == "aws" ]]; then
+            if [[ -z "${{ inputs.assume_role_arn }}" ]]; then
+              echo "Error: assume_role_arn input is required when auth_method is 'aws'."
+              exit 1
+            fi
+            if [[ -z "${{ inputs.region }}" ]]; then
+              echo "Error: region input is required when auth_method is 'aws'."
+              exit 1
+            fi
+          fi
+
+          if [[ "${{ inputs.auth_method }}" == "azure" ]]; then
+            if [[ -z "${{ secrets.TERRAFORM_CHECK_AZURE_CLIENT_ID }}" ]]; then
+              echo "Error: TERRAFORM_CHECK_AZURE_CLIENT_ID secret is required when auth_method is 'azure'."
+              exit 1
+            fi
+            if [[ -z "${{ secrets.TERRAFORM_CHECK_AZURE_TENANT_ID }}" ]]; then
+              echo "Error: TERRAFORM_CHECK_AZURE_TENANT_ID secret is required when auth_method is 'azure'."
+              exit 1
+            fi
+            if [[ -z "${{ secrets.TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID }}" ]]; then
+              echo "Error: TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID secret is required when auth_method is 'azure'."
+              exit 1
+            fi
+          fi
+
+          echo "auth_method=${{ inputs.auth_method }}" >> $GITHUB_OUTPUT
+  check:
+    name: "Run Tests"
+    runs-on: ubuntu-latest
+    needs: validate-inputs
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+
+      - id: dependencies
+        name: Setup asdf
+        # We use the 'setup' variant of this action, because we have some custom behavior in
+        # our .tool-versions file and Makefile to install plugins from outside the default registry.
+        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47
+
+      - id: cache-restore
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        # If we've cached the asdf tools, restore them based on the hash of the .tool-versions file.
+        name: Restore cached asdf tools
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
+
+      - id: configure
+        name: Setup Repository for Checks
+        # Ensure the 'repo' tool is installed, set up git to make the Makefile happy, and then configure to clone LCAF.
+        shell: bash
+        run: |
+          mkdir -p ~/.local/bin
+          curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.local/bin/repo
+          chmod +x ~/.local/bin/repo
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          set -x
+          git config user.name "GitHub Actions"
+          git config user.email "noreply@launch.nttdata.com"
+          if [[ "${{ needs.validate-inputs.outputs.auth_method }}" == "aws" ]]; then
+            export AWS_REGION=${{ inputs.region }}
+          elif [[ "${{ needs.validate-inputs.outputs.auth_method }}" == "azure" ]]; then
+            export ARM_SUBSCRIPTION_ID=${{ secrets.TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID }}
+          fi
+          make configure
+
+      - id: save-cache
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        name: Cache asdf tools
+        # If we didn't restore the asdf tools, save them based on the hash of the .tool-versions file.
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
+
+      - id: lint
+        name: "make lint"
+        run: |
+          make lint
+
+      - id: configure-aws-credentials
+        name: Configure AWS credentials
+        if: needs.validate-inputs.outputs.auth_method == 'aws'
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ inputs.assume_role_arn }}
+          role-session-name: ${{ github.run_id }}
+          aws-region: ${{ inputs.region }}
+
+      - id: create-aws-profile
+        name: "Create AWS Profile"
+        if: needs.validate-inputs.outputs.auth_method == 'aws'
+        # Works around the interactions of aws-actions/configure-aws-credentials with 4.x.x AWS TF provider.
+        # In short, we need to create the profile in ~/.aws/credentials for the provider to use, but also need
+        # to remove line setting the profile in our examples, or we see failures to initialize the provider.
+        run: |
+          set -x
+          mkdir -p ~/.aws
+          echo "[default]" > ~/.aws/credentials
+          echo "aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" >> ~/.aws/credentials
+          echo "aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> ~/.aws/credentials
+          echo "aws_session_token=${{ secrets.AWS_SESSION_TOKEN }}" >> ~/.aws/credentials
+          # Fixup examples' provider.tf by dropping references to the profile, so that we can use the default profile.
+          find examples -type f -name "provider.tf" -mindepth 2 -maxdepth 2 -exec bash -c 'grep -vE "profile\s=" "$1" > $1.tmp && mv $1.tmp $1' bash {} \;
+
+      - id: azure-login
+        name: Azure login
+        if: needs.validate-inputs.outputs.auth_method == 'azure'
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        with:
+          client-id: ${{ secrets.TERRAFORM_CHECK_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.TERRAFORM_CHECK_AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID }}
+
+      - id: test
+        name: "make test"
+        run: |
+          make test

--- a/docs/reusable-terraform-check-aws.md
+++ b/docs/reusable-terraform-check-aws.md
@@ -1,3 +1,8 @@
+> [!CAUTION]
+> Deprecation Notice
+>
+> This workflow will be deprecated with the 1.0.0 release of launch-workflows.
+
 # Check a Terraform Module in AWS
 
 Performs a series of checks of a Terraform module, including deploying the example modules to AWS.

--- a/docs/reusable-terraform-check-azure.md
+++ b/docs/reusable-terraform-check-azure.md
@@ -1,3 +1,8 @@
+> [!CAUTION]
+> Deprecation Notice
+>
+> This workflow will be deprecated with the 1.0.0 release of launch-workflows.
+
 # Check a Terraform Module in Azure
 
 Performs a series of checks of a Terraform module, including deploying the example modules to Azure.

--- a/docs/reusable-terraform-check.md
+++ b/docs/reusable-terraform-check.md
@@ -1,0 +1,160 @@
+# Check a Terraform Module
+
+Performs a series of checks of a Terraform module, including linting the Terraform code via `make lint`, and deploying the example modules to a cloud provider (or no provider at all) and running the golang tests via the `make test` target. This workflow unifies the previously separate `reusable-terraform-check-aws.yml` and `reusable-terraform-check-azure.yml` workflows into a single, provider-agnostic workflow controlled by the `auth_method` input.
+
+This workflow wraps both the `make lint` and `make test` targets in the Makefile.
+
+## Usage
+
+### No cloud authentication (`auth_method: none`)
+
+Use this when your module does not require cloud credentials to run tests (e.g., pure Terraform logic tests, mocked providers):
+
+```yaml
+name: Check Terraform Code
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches: [ main ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check:
+    name: "Check Terraform Code"
+    permissions:
+      contents: read
+      id-token: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@ref
+    with:
+      auth_method: "none"
+```
+
+### AWS authentication (`auth_method: aws`)
+
+Use this when your module deploys example resources to AWS. Authentication is performed via OIDC using a role you provide:
+
+```yaml
+name: Check AWS Terraform Code
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches: [ main ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check:
+    name: "Check AWS Terraform Code"
+    permissions:
+      contents: read
+      id-token: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@ref
+    with:
+      auth_method: "aws"
+      assume_role_arn: "arn:aws:iam::123456789012:role/my-assumed-role" # optional, falls back to TERRAFORM_CHECK_AWS_ASSUME_ROLE_ARN variable
+      region: "us-east-2"  # optional, falls back to TERRAFORM_CHECK_AWS_REGION variable
+```
+
+Replace `ref` with an appropriate ref to this repository, and replace `assume_role_arn` and `region` with values of your choosing. If either is not provided, they fall back to the `TERRAFORM_CHECK_AWS_ASSUME_ROLE_ARN` and `TERRAFORM_CHECK_AWS_REGION` variables set at the repository, organization, or enterprise level.
+
+### Azure authentication (`auth_method: azure`)
+
+Use this when your module deploys example resources to Azure. Authentication is performed via OIDC using Azure credentials passed as secrets:
+
+```yaml
+name: Check Azure Terraform Code
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches: [ main ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check:
+    name: "Check Azure Terraform Code"
+    permissions:
+      contents: read
+      id-token: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@ref
+    with:
+      auth_method: "azure"
+    secrets: inherit # pragma: allowlist secret
+
+    # For usage outside the launchbynttdata organization, pass the secrets explicitly:
+    # secrets:
+    #   TERRAFORM_CHECK_AZURE_CLIENT_ID: ${{ secrets.your_azure_client_id_secret }}
+    #   TERRAFORM_CHECK_AZURE_TENANT_ID: ${{ secrets.your_azure_tenant_id_secret }}
+    #   TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID: ${{ secrets.your_azure_subscription_id_secret }}
+```
+
+Replace `ref` with an appropriate ref to this repository. For more information on OIDC setup for Azure, see the [azure/login action documentation](https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended).
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `auth_method` | Authentication method to use. Valid values are `none`, `aws`, and `azure`. | Yes | — |
+| `assume_role_arn` | ARN of the IAM role to assume. Required when `auth_method` is `aws`. | No | `${{ vars.TERRAFORM_CHECK_AWS_ASSUME_ROLE_ARN }}` |
+| `region` | AWS region to use when deploying test resources. Only used when `auth_method` is `aws`. | No | `${{ vars.TERRAFORM_CHECK_AWS_REGION }}` |
+
+## Secrets
+
+| Name | Description | Required |
+|------|-------------|----------|
+| `TERRAFORM_CHECK_AZURE_CLIENT_ID` | Azure client ID for OIDC authentication. Required when `auth_method` is `azure`. | No* |
+| `TERRAFORM_CHECK_AZURE_TENANT_ID` | Azure tenant ID for OIDC authentication. Required when `auth_method` is `azure`. | No* |
+| `TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID` | Azure subscription ID for OIDC authentication. Required when `auth_method` is `azure`. | No* |
+
+*These secrets are declared as optional at the workflow level to allow reuse in non-Azure contexts, but the workflow will fail at the `validate-inputs` job if any of them are missing when `auth_method` is `azure`.
+
+## Migrating from the provider-specific workflows
+
+If you are currently using `reusable-terraform-check-aws.yml`, replace the `uses` reference and add `auth_method: "aws"`:
+
+```yaml
+# Before
+uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-aws.yml@ref
+with:
+  assume_role_arn: "arn:aws:iam::123456789012:role/my-assumed-role"
+
+# After
+uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@ref
+with:
+  auth_method: "aws"
+  assume_role_arn: "arn:aws:iam::123456789012:role/my-assumed-role"
+```
+
+If you are currently using `reusable-terraform-check-azure.yml`, replace the `uses` reference and add `auth_method: "azure"`:
+
+```yaml
+# Before
+uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-azure.yml@ref
+secrets: inherit # pragma: allowlist secret
+
+# After
+uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@ref
+with:
+  auth_method: "azure"
+secrets: inherit # pragma: allowlist secret
+```
+
+For our Terraform modules, the `auth_method` can be derived automatically from the repository name: repositories prefixed with `tf-aws` use AWS authentication, those prefixed with `tf-az` use Azure authentication, and all others use no authentication:
+
+```yaml
+uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check.yml@ref
+with:
+  auth_method: ${{ startsWith(github.event.repository.name, 'tf-aws') && 'aws' || startsWith(github.event.repository.name, 'tf-az') && 'azure' || 'none' }}
+secrets: inherit # pragma: allowlist secret
+```
+


### PR DESCRIPTION
I still need to do some further testing, but I think I like this pattern better than having a workflow for each type of cloud we'd auth against.

In the future if we needed to add authentication for another provider, we would:

- Add optional inputs to cover the needs of that provider
- Add optional secrets to cover the needs of that provider
- Add to the auth_method description and validation logic to allow a new value, as well as validate the necessary inputs and secrets have actually been set
- Adjust the logic in the `configure` step to set any required environment variables
- Add a step with an appropriate `if` to trigger your specific authentication steps prior to executing the `test` step

I intend to have this workflow exist in parallel to the cloud-specific variants while we transition, and once we're fully over I'll drop the cloud-specific ones. I would like to extend this pattern to the Terragrunt workflows as well, though the ephemeral deploy/destroy workflows will remain AWS-only until we can come up with a better solution to handle those on Azure.

To fully replace our existing workflows, we'll need a new ruleset at the organization level to force the check to be required. I'm going to hold off on that until we have a better way to roll this workflow out org-wide in place.