### PR TITLE
fix: dependabot automerge with alternate identity

### DIFF
--- a/.github/workflows/reusable-pr-dependabot-automerge.yml
+++ b/.github/workflows/reusable-pr-dependabot-automerge.yml
@@ -3,12 +3,19 @@ name: Dependabot Auto-Merge
 on:
   workflow_call:
     inputs:
-      # No inputs needed for this workflow, but we need to define at least one to make it callable.
-      placeholder:
-        type: string
+      skeleton_update_app_id:
+        description: "The GitHub App ID of the app to use for authentication when
+          auto-merging. The app must be installed on the repository and have
+          permissions to read and write code, as well as create pull requests."
         required: false
-        default: ""
-        description: "This input is not used, but is required to make this workflow callable."
+        type: string
+        default: ${{ vars.LAUNCH_SKELETON_UPDATE_APP_ID }}
+    secrets:
+      LAUNCH_SKELETON_UPDATE_KEY:
+        description: "The private key for the GitHub App used for authentication when
+          auto-merging. The app must be installed on the repository and have
+          permissions to read and write code, as well as create pull requests."
+        required: true
 
 permissions:
   contents: write
@@ -20,8 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      # By passing the token of a GitHub app and having that identity perform the auto-merge,
+      # Dependabot no longer owns the PR and subsequent actions runs that would otherwise be 
+      # skipped for Dependabot-authored PRs (release on merge to main) will run as expected.
+      - id: get-app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          app-id: ${{ inputs.skeleton_update_app_id }}
+          private-key: ${{ secrets.LAUNCH_SKELETON_UPDATE_KEY }}
+
       - name: Enable auto-merge
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"

--- a/docs/reusable-pr-dependabot-automerge.md
+++ b/docs/reusable-pr-dependabot-automerge.md
@@ -4,6 +4,8 @@ Automatically enables GitHub's auto-merge (squash strategy) on pull requests cre
 
 This workflow only runs when the PR actor is `dependabot[bot]`. For all other actors, the job is skipped.
 
+A GitHub App token is used to perform the merge rather than `GITHUB_TOKEN`. This ensures that the resulting push to the default branch is attributed to the GitHub App rather than `dependabot[bot]`, which allows downstream workflows (such as a release process) to be triggered as expected. When Dependabot performs the merge directly, GitHub suppresses re-triggering of actions to prevent infinite loops.
+
 ## Usage
 
 Add the following workflow to your repository (suggested name: `.github/workflows/pr-dependabot-automerge.yml`):
@@ -26,6 +28,8 @@ jobs:
       contents: write
       pull-requests: write
     uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-dependabot-automerge.yml@ref
+    with:
+      skeleton_update_app_id: ${{ vars.LAUNCH_SKELETON_UPDATE_APP_ID }}
     secrets: inherit
 ```
 
@@ -36,8 +40,16 @@ Be sure you replace `ref` with an appropriate ref to this repository.
 
 ## Inputs
 
-This workflow has no configurable inputs.
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `skeleton_update_app_id` | `string` | No | `vars.LAUNCH_SKELETON_UPDATE_APP_ID` | The GitHub App ID to use for authentication when enabling auto-merge. The app must be installed on the repository with permissions to read and write code and create pull requests. |
+
+## Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `LAUNCH_SKELETON_UPDATE_KEY` | Yes | The private key for the GitHub App used for authentication. |
 
 ## Required Permissions
 
-The calling workflow must grant `contents: write` and `pull-requests: write` permissions so that the `GITHUB_TOKEN` can enable auto-merge on the pull request.
+The calling workflow must grant `contents: write` and `pull-requests: write` permissions. The GitHub App identified by `skeleton_update_app_id` and `LAUNCH_SKELETON_UPDATE_KEY` must be installed on the repository with permissions to read and write code and to read and write pull requests.


### PR DESCRIPTION
Uses the auto-approver identity as the merge source. This allows us to trigger actions off merge to main after a Dependabot PR merges, so that we're correctly tagging and releasing dependency updates.

Will become `0.15.1` and eventually `1.0.0` provided nothing else is found.