### PR TITLE
fix: work around legacy checks not having write on statuses

### DIFF
--- a/.github/workflows/reusable-terraform-check-aws.yml
+++ b/.github/workflows/reusable-terraform-check-aws.yml
@@ -14,17 +14,30 @@ on:
         default: "us-east-2"
         required: true
         type: string
+      status_check_app_id:
+        description: "GitHub App ID used to generate a token for writing commit statuses."
+        required: false
+        type: string
+        default: ${{ vars.LAUNCH_STATUS_CHECK_APP_ID }}
+    secrets:
+      LAUNCH_STATUS_CHECK_KEY:
+        required: true
 
 permissions:
   id-token: write
   contents: read
-  statuses: write
 
 jobs:
   check:
     name: "Check AWS Terraform Code"
     runs-on: ubuntu-latest
     steps:
+      - id: get-app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          app-id: ${{ inputs.status_check_app_id }}
+          private-key: ${{ secrets.LAUNCH_STATUS_CHECK_KEY }}
+
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
@@ -71,6 +84,7 @@ jobs:
           check_name: "Terraform Lint"
           status: "pending"
           description: "Terraform lint check is running..."
+          github_token: ${{ steps.get-app-token.outputs.token }}
 
       - id: lint
         name: "make lint"
@@ -85,6 +99,7 @@ jobs:
           status: ${{ steps.lint.outcome == 'success' && 'success' || steps.lint.outcome
             == 'failure' && 'failure' || 'error' }}
           description: "Terraform lint ${{ steps.lint.outcome }}"
+          github_token: ${{ steps.get-app-token.outputs.token }}
 
       - id: aws-login
         name: Configure AWS credentials
@@ -114,6 +129,7 @@ jobs:
           check_name: "Terraform Tests"
           status: "pending"
           description: "Terraform tests are running..."
+          github_token: ${{ steps.get-app-token.outputs.token }}
 
       - id: test
         name: "make test"
@@ -128,3 +144,4 @@ jobs:
           status: ${{ steps.test.outcome == 'success' && 'success' || steps.test.outcome
             == 'failure' && 'failure' || 'error' }}
           description: "Terraform tests ${{ steps.test.outcome }}"
+          github_token: ${{ steps.get-app-token.outputs.token }}

--- a/.github/workflows/reusable-terraform-check-azure.yml
+++ b/.github/workflows/reusable-terraform-check-azure.yml
@@ -2,6 +2,12 @@ name: Check Azure Terraform Code
 
 on:
   workflow_call:
+    inputs:
+      status_check_app_id:
+        description: "GitHub App ID used to generate a token for writing commit statuses."
+        required: false
+        type: string
+        default: ${{ vars.LAUNCH_STATUS_CHECK_APP_ID }}
     secrets:
       TERRAFORM_CHECK_AZURE_CLIENT_ID:
         required: true
@@ -9,17 +15,24 @@ on:
         required: true
       TERRAFORM_CHECK_AZURE_SUBSCRIPTION_ID:
         required: true
+      LAUNCH_STATUS_CHECK_KEY:
+        required: true
 
 permissions:
   id-token: write
   contents: read
-  statuses: write
 
 jobs:
   check:
     name: "Check Azure Terraform Code"
     runs-on: ubuntu-latest
     steps:
+      - id: get-app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          app-id: ${{ inputs.status_check_app_id }}
+          private-key: ${{ secrets.LAUNCH_STATUS_CHECK_KEY }}
+
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
@@ -67,6 +80,7 @@ jobs:
           check_name: "Terraform Lint"
           status: "pending"
           description: "Terraform lint check is running..."
+          github_token: ${{ steps.get-app-token.outputs.token }}
 
       - id: lint
         name: "make lint"
@@ -81,6 +95,7 @@ jobs:
           status: ${{ steps.lint.outcome == 'success' && 'success' || steps.lint.outcome
             == 'failure' && 'failure' || 'error' }}
           description: "Terraform lint ${{ steps.lint.outcome }}"
+          github_token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
@@ -95,6 +110,7 @@ jobs:
           check_name: "Terraform Tests"
           status: "pending"
           description: "Terraform tests are running..."
+          github_token: ${{ steps.get-app-token.outputs.token }}
 
       - id: test
         name: "make test"
@@ -109,3 +125,4 @@ jobs:
           status: ${{ steps.test.outcome == 'success' && 'success' || steps.test.outcome
             == 'failure' && 'failure' || 'error' }}
           description: "Terraform tests ${{ steps.test.outcome }}"
+          github_token: ${{ steps.get-app-token.outputs.token }}


### PR DESCRIPTION
Works around an issue with legacy repos trying to consume updated versions of launch-workflows and failing workflow invocation due to a missing `statuses: write` permission.

One option would have been to just not call these status checks at all, but if we don't, we lose out on the opportunity to put the new status checks in `evaluate` mode and use them to measure completeness of the migration.

A narrowly-scoped GitHub app has been created to allow these legacy workflows to publish status checks, which allows us to drop the requirement for `statuses: write` on the legacy workflows.

Validated this fix with a failed Dependabot branch here: https://github.com/launchbynttdata/tf-azurerm-module_primitive-container_registry_token/actions/runs/25461504514/job/74704568650?pr=44