### PR TITLE
feat: auto-update incorporates automated pre-commit fixes

### DIFF
--- a/.github/workflows/reusable-update-from-skeleton.yml
+++ b/.github/workflows/reusable-update-from-skeleton.yml
@@ -4,13 +4,15 @@ on:
   workflow_call:
     inputs:
       recopy:
-        description: "Perform a full recopy instead of an incremental update (overwrites
+        description:
+          "Perform a full recopy instead of an incremental update (overwrites
           all templated files), and re-runs any tasks defined in copier.yml. The
           resulting PR will require manual review and merging."
         type: boolean
         default: false
       skeleton_update_app_id:
-        description: "The GitHub App ID of the app to use for authentication when
+        description:
+          "The GitHub App ID of the app to use for authentication when
           pushing updates. The app must be installed on the repository and have
           permissions to read and write code, as well as create pull requests."
         required: false
@@ -18,7 +20,8 @@ on:
         default: ${{ vars.LAUNCH_SKELETON_UPDATE_APP_ID }}
     secrets:
       LAUNCH_SKELETON_UPDATE_KEY:
-        description: "The private key for the GitHub App used for authentication when
+        description:
+          "The private key for the GitHub App used for authentication when
           pushing updates. The app must be installed on the repository and have
           permissions to read and write code, as well as create pull requests."
         required: true
@@ -43,6 +46,26 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with:
           token: ${{ steps.get-app-token.outputs.token }}
+
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47
+
+      - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        name: Restore cached asdf tools
+        id: cache
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
+
+      - name: Install asdf tools
+        run: asdf install
+
+      - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        name: Cache asdf tools
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
       - id: setup-python
         name: Set up Python 3.14
@@ -130,6 +153,8 @@ jobs:
                 fi
               else
                 rm -f "$PRE_COMMIT_LOG"
+                echo "No merge conflicts detected, running all pre-commit checks"
+                pre-commit run --all-files || pre-commit run --all-files
                 echo "Pre-commit checks passed"
                 echo "pre_commit_passed=true" >> "$GITHUB_OUTPUT"
               fi

--- a/docs/reusable-update-from-skeleton.md
+++ b/docs/reusable-update-from-skeleton.md
@@ -4,22 +4,27 @@ Keeps a repository in sync with its upstream [Copier](https://copier.readthedocs
 
 ```mermaid
 flowchart TD
-  A[Workflow Triggered] --> B[Run copier update/recopy]
-  B --> C{Changes detected?}
-  C -- No --> D[Done]
-  C -- Yes --> E{Pre-commit passes?}
-  E -- Yes --> F[Create PR with auto-merge]
-  E -- No --> G[Create PR requiring manual review]
+  A[Workflow Triggered] --> B[Install asdf tools]
+  B --> C[Run copier update/recopy]
+  C --> D{Changes detected?}
+  D -- No --> E[Done]
+  D -- Yes --> F{Merge conflicts?}
+  F -- Yes --> G[Create PR requiring manual review]
+  F -- No --> H[Run all pre-commit checks]
+  H --> I[Create PR with auto-merge]
 ```
 
 ## Behavior
 
-1. **Copier update** — Runs `copier update --defaults --trust` to pull the latest changes from the skeleton template. If the repository's `prerelease` custom property is `true`, the `--prerelease` flag is added to pick up prerelease skeleton versions.
-2. **Recopy mode** — When `recopy` is set to `true`, runs `copier recopy --defaults --trust --overwrite` instead, which overwrites all templated files. Recopy PRs always require manual review.
-3. **Pre-commit validation** — If a `.pre-commit-config.yaml` exists, runs `check-merge-conflict` against all files to detect merge conflict markers.
-4. **Pull request creation**:
+1. **Tool installation** — Installs tools defined in the repository's `.tool-versions` file via asdf (with caching), then installs Copier and pre-commit via uv.
+2. **Copier update** — Runs `copier update --defaults --trust` to pull the latest changes from the skeleton template. If the repository's `prerelease` custom property is `true`, the `--prerelease` flag is added to pick up prerelease skeleton versions.
+3. **Recopy mode** — When `recopy` is set to `true`, runs `copier recopy --defaults --trust --overwrite` instead, which overwrites all templated files. Recopy PRs always require manual review.
+4. **Pre-commit validation** — If a `.pre-commit-config.yaml` exists, validation runs in two phases:
+   - First, `check-merge-conflict` runs against all files. If merge conflict markers are found, the PR is flagged for manual review.
+   - If no conflicts are found, all pre-commit hooks run against all files. Any automatic fixes (formatting, trailing whitespace, etc.) are included in the resulting commit.
+5. **Pull request creation**:
    - If pre-commit passes and recopy is not enabled, a PR titled `chore: update from skeleton` is created with auto-merge enabled.
-   - If pre-commit fails or recopy is enabled, a PR titled `fix: update from skeleton` is created and flagged for manual review. Any files with merge conflict markers are listed in the PR body.
+   - If pre-commit fails (merge conflicts) or recopy is enabled, a PR titled `fix: update from skeleton` is created and flagged for manual review. Any files with merge conflict markers are listed in the PR body.
 
 ## Usage
 


### PR DESCRIPTION
The automatic update workflow will now run a full set of pre-commit checks in addition to the preexisting `check-merge-conflict` check.

The current behavior is preserved, `check-merge-conflict` failures trigger a manual PR review. If `check-merge-conflict` does not fail, the full set of pre-commit checks will be run against the repo, and any changes as a result (formatting, trailing whitespace, etc.) will be incorporated into the automatic update PR (while still rejecting true pre-commit failures). This should allow us to safely mutate e.g. terraform-docs configuration and have those changes automatically reflected in the autogenerated portions of README.md.

Because we now need to `asdf install` in this workflow, I expect a modest increase in runtime even with caching enabled. The normal case for this workflow is that it runs off-hours on a schedule, so I don't anticipate much real-world impact, but figured it was worth calling out.