### PR TITLE
fix: auto-update tool installation

### DIFF
--- a/.github/workflows/reusable-update-from-skeleton.yml
+++ b/.github/workflows/reusable-update-from-skeleton.yml
@@ -58,7 +58,10 @@ jobs:
           key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
       - name: Install asdf dependencies using Makefile
-        run: make configure
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          make configure
 
       - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
         name: Cache asdf tools

--- a/.github/workflows/reusable-update-from-skeleton.yml
+++ b/.github/workflows/reusable-update-from-skeleton.yml
@@ -57,8 +57,8 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
-      - name: Install asdf tools
-        run: asdf install
+      - name: Install asdf dependencies using Makefile
+        run: make configure
 
       - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
         name: Cache asdf tools


### PR DESCRIPTION
Resolves an issue where a bare `asdf install` is insufficient to pull in our tools and instead replaces it with `make configure`.

Validated with [this branch run](https://github.com/launchbynttdata/tf-aws-module_primitive-api_gateway_v2/actions/runs/25941336699) that spawned [a PR including all the expected changes](https://github.com/launchbynttdata/tf-aws-module_primitive-api_gateway_v2/pull/29/changes) to the README.md files (drop provider, fix sort order). Since this was spawned off a branch, I will close this PR and update through the normal route once this workflow change merges.