### PR TITLE
fix: allow GraphQL time to become consistent before releasing

### DIFF
--- a/.github/workflows/reusable-release-on-merge.yml
+++ b/.github/workflows/reusable-release-on-merge.yml
@@ -3,6 +3,13 @@ name: Create and Publish Release
 on:
   workflow_call:
     inputs:
+      graphql_delay:
+        type: number
+        description: "The delay in seconds before invoking the release process. This can
+          help ensure that PRs associated with commits made through the GraphQL API are
+          consistent before the release process checks for merged PRs. Default: 15"
+        required: false
+        default: 15
       config_name:
         type: string
         description: "The name of the release drafter config file to use. Default:
@@ -55,6 +62,10 @@ jobs:
     outputs:
       release_version: ${{ steps.release-drafter.outputs.tag_name }}
     steps:
+      - name: Delay for GraphQL consistency
+        run: sleep $GRAPHQL_DELAY
+        env:
+          GRAPHQL_DELAY: ${{ inputs.graphql_delay }}
       - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7
         id: release-drafter
         with:


### PR DESCRIPTION
I've been chasing a weird issue where sometimes when release-drafter kicks off, it's not able to retrieve information about the most recent commit and instead shows `No Changes`. I stumbled across some guidance when combing through release-drafter's issue pages looking for an unrelated question, and it seems to be related to the way GitHub handles caching across its REST and GraphQL interfaces.

This change resolves the issue with a short sleep, which allows the GraphQL queries to become consistent. This is fixed in a later version of release-drafter, but is behind a major version upgrade that we'll need to consume first, so I'm putting this workaround in place for now and we can remove it once we're on a version >= `7.3.0`.

This does add a 15-second delay to all release workflows, but is an acceptable tradeoff for the added consistency given that our release creation has never been a time-sensitive part of the process.