### PR TITLE
fix: environment support on plan-only workflow

### DIFF
--- a/.github/workflows/reusable-terragrunt-deploy.yml
+++ b/.github/workflows/reusable-terragrunt-deploy.yml
@@ -47,7 +47,7 @@ on:
         required: true
         type: string
       gh_environment:
-        description: "GitHub Environment to deploy to (e.g. test, production)."
+        description: "GitHub Environment to deploy to (e.g. test, production). Leave blank to use repo-level values."
         required: false
         type: string
       tg_dir:

--- a/.github/workflows/reusable-terragrunt-plan-only.yml
+++ b/.github/workflows/reusable-terragrunt-plan-only.yml
@@ -113,7 +113,9 @@ jobs:
   validate-inputs:
     name: "Validate Inputs"
     runs-on: ubuntu-latest
-    environment: ${{ inputs.gh_environment }}
+    environment:
+      name: ${{ inputs.gh_environment }}
+      deployment: false
     outputs:
       auth_aws: ${{ steps.validate.outputs.auth_aws }}
       auth_azure: ${{ steps.validate.outputs.auth_azure }}
@@ -195,7 +197,9 @@ jobs:
   plan:
     name: "Plan ${{ inputs.tg_dir }}"
     runs-on: ubuntu-latest
-    environment: ${{ inputs.gh_environment }}
+    environment:
+      name: ${{ inputs.gh_environment }}
+      deployment: false
     needs: validate-inputs
     outputs:
       added: ${{ steps.comment.outputs.num-resources-created }}

--- a/.github/workflows/reusable-terragrunt-plan-only.yml
+++ b/.github/workflows/reusable-terragrunt-plan-only.yml
@@ -49,6 +49,10 @@ on:
           to the repository root, e.g. platform/test/us-east-1/000)"
         required: true
         type: string
+      gh_environment:
+        description: "GitHub Environment to deploy to (e.g. test, production). Leave blank to use repo-level values."
+        required: false
+        type: string
       comment_plan_results:
         description: "Post a comment with the plan results when called from a pull request."
         required: false
@@ -109,6 +113,7 @@ jobs:
   validate-inputs:
     name: "Validate Inputs"
     runs-on: ubuntu-latest
+    environment: ${{ inputs.gh_environment }}
     outputs:
       auth_aws: ${{ steps.validate.outputs.auth_aws }}
       auth_azure: ${{ steps.validate.outputs.auth_azure }}
@@ -190,6 +195,7 @@ jobs:
   plan:
     name: "Plan ${{ inputs.tg_dir }}"
     runs-on: ubuntu-latest
+    environment: ${{ inputs.gh_environment }}
     needs: validate-inputs
     outputs:
       added: ${{ steps.comment.outputs.num-resources-created }}

--- a/docs/reusable-terragrunt-deploy.md
+++ b/docs/reusable-terragrunt-deploy.md
@@ -183,7 +183,7 @@ jobs:
 | `git_branch` | Branch triggering this deployment. | Yes | — |
 | `tf_version` | Version of Terraform to utilize. | Yes | `1.5.5` |
 | `tg_version` | Version of Terragrunt to utilize. | Yes | — |
-| `gh_environment` | GitHub Environment to deploy to (e.g. test, production). | No | — |
+| `gh_environment` | GitHub Environment to deploy to (e.g. test, production). Leave blank to use repo-level values. | No | — |
 | `tg_dir` | Folder containing the Terragrunt configuration to deploy (relative to the repository root). | Yes | — |
 | `aws_auth_region` | AWS region to use for authentication. Required when `auth_method` includes `aws`. | No | — |
 | `aws_assume_role_arn` | ARN of the role to assume prior to Terragrunt invocation. Required when `auth_method` includes `aws`. Defaults to `vars.DEPLOY_ROLE_ARN`. | No | `${{ vars.DEPLOY_ROLE_ARN }}` |

--- a/docs/reusable-terragrunt-plan-only.md
+++ b/docs/reusable-terragrunt-plan-only.md
@@ -53,6 +53,7 @@ jobs:
       tf_version: ${{ needs.get-tg-versions.outputs.tf_version }}
       tg_version: ${{ needs.get-tg-versions.outputs.tg_version }}
       tg_dir: "platform/${{ matrix.terragrunt_environment.environment }}/${{ matrix.terragrunt_environment.region }}/${{ matrix.terragrunt_environment.instance }}"
+      gh_environment: ${{ matrix.terragrunt_environment.environment }}
       aws_auth_region: "us-east-2"
       aws_assume_role_arn: "arn:aws:iam::123456789012:role/my-assumed-role"
 ```
@@ -227,6 +228,7 @@ Replace `ref` with an appropriate ref to this repository, and replace the `aws_a
 | `tf_version` | Version of Terraform to utilize. | Yes | `1.5.5` |
 | `tg_version` | Version of Terragrunt to utilize. | Yes | — |
 | `tg_dir` | Folder containing the Terragrunt configuration to plan (relative to the repository root). | Yes | — |
+| `gh_environment` | GitHub Environment to deploy to (e.g. test, production). Leave blank to use repo-level values. | No | — |
 | `aws_auth_region` | AWS region to use for authentication. Required when `auth_method` includes `aws`. | No | — |
 | `aws_assume_role_arn` | ARN of the role to assume prior to Terragrunt invocation. Required when `auth_method` includes `aws`. | No | — |
 | `github_app_id` | GitHub App ID for authentication. Required when `auth_method` includes `github`. Defaults to `vars.TERRAGRUNT_DEPLOY_GITHUB_APP_ID`. | No | `${{ vars.TERRAGRUNT_DEPLOY_GITHUB_APP_ID }}` |


### PR DESCRIPTION
Adds environment support to our plan-only workflow to match the deployment workflow. This will allow us to correctly dig environment-specific values out of the repo configuration.

GitHub has very recently added support for using an environment _without_ triggering a deployment, details here: https://github.com/orgs/community/discussions/36919. There may be some compatibility issues with deployment protection rulesets, but this isn't a feature we utilize today and it's not on my radar for the near future. If one day we decide to implement that, we'll need to reassess this workflow default.

The initial commit and test of this PR didn't include that `deployment: false` setting, but the second noop push did, and the observed behavior is correct; a second deployment record wasn't created on my [test PR](https://github.com/launchbynttdata/launch-terraform-registry/pull/23).

Includes a small clarifying description tweak for the deployment workflow.