### PR TITLE
feat: add reusable pre-commit workflow

### DIFF
--- a/.github/workflows/pull-request-precommit-checks.yml
+++ b/.github/workflows/pull-request-precommit-checks.yml
@@ -9,69 +9,7 @@ jobs:
   pre-commit:
     name: Pre-Commit Checks
     permissions:
-      pull-requests: read
       contents: read
+      pull-requests: read
       statuses: write
-    runs-on: ubuntu-latest
-    steps:
-      - id: checkout
-        name: Checkout code
-        uses: actions/checkout@v6
-
-      - id: setup-python
-        name: Set up Python 3.14
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
-        with:
-          python-version: 3.14
-
-      - id: install-tools
-        name: Install Tools with uv
-        run: |
-          uv tool install pre-commit --with pre-commit-uv
-
-      # If we've cached the pre-commit environment, restore it based on the hash of the pre-commit config.
-      - id: cache
-        name: Restore cached pre-commit environment
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-      - id: setup-asdf
-        name: Setup ASDF
-        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47
-
-      - id: restore-asdf-tools
-        name: Restore ASDF tools from cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
-          path: |
-            ~/.asdf/plugins
-            ~/.asdf/installs
-
-      - id: install-asdf
-        name: Install ASDF tools on cache-miss
-        if: ${{ steps.restore-asdf-tools.outputs.cache-hit != 'true' }}
-        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
-
-      - id: asdf-reshim
-        name: Reshim installed ASDF tools
-        run: asdf reshim
-
-      - id: pre-commit
-        name: Run pre-commit checks
-        run: uv run pre-commit run --all-files
-
-      - id: set-status-check
-        name: Set Status Check
-        if: always()
-        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
-        with:
-          check_name: "Pre-Commit Checks"
-          status: ${{ steps.pre-commit.outcome == 'success' && 'success' ||
-            steps.pre-commit.outcome == 'failure' && 'failure' || 'error' }}
-          description: "Pre-Commit Checks ${{steps.pre-commit.outcome }}"
-          target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
-            github.run_id }}"
+    uses: ./.github/workflows/reusable-pre-commit-checks.yml

--- a/.github/workflows/reusable-pre-commit-checks.yml
+++ b/.github/workflows/reusable-pre-commit-checks.yml
@@ -1,0 +1,90 @@
+name: Dependabot Auto-Merge
+
+on:
+  workflow_call:
+    inputs:
+      # Placeholder input: this workflow currently takes no real inputs, but
+      # `workflow_call` requires the `inputs` map to be present.
+      _placeholder:
+        description: "Unused. Reserved for future use; do not set."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  pre-commit:
+    name: Pre-Commit Checks
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        name: Checkout code
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+
+      - id: setup-python
+        name: Set up Python 3.14
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          python-version: 3.14
+
+      - id: install-tools
+        name: Install Tools with uv
+        run: |
+          uv tool install pre-commit --with pre-commit-uv
+
+      # If we've cached the pre-commit environment, restore it based on the hash of the pre-commit config.
+      - id: cache
+        name: Restore cached pre-commit environment
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - id: setup-asdf
+        name: Setup ASDF
+        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47
+
+      - id: restore-asdf-tools
+        name: Restore ASDF tools from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-asdf-
+          path: |
+            ~/.asdf/plugins
+            ~/.asdf/installs
+
+      - id: install-asdf
+        name: Install ASDF tools on cache-miss
+        if: ${{ steps.restore-asdf-tools.outputs.cache-hit != 'true' }}
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
+
+      - id: asdf-reshim
+        name: Reshim installed ASDF tools
+        run: asdf reshim
+
+      - id: pre-commit
+        name: Run pre-commit checks
+        run: |
+          uv run pre-commit run --all-files
+
+      - id: set-status-check
+        name: Set Status Check
+        if: always()
+        uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@edddecdce4590f94f30d0fdfdf991d8a692fe8dd
+        with:
+          check_name: "Pre-Commit Checks"
+          status: ${{ steps.pre-commit.outcome == 'success' && 'success' ||
+            steps.pre-commit.outcome == 'failure' && 'failure' || 'error' }}
+          description: "Pre-Commit Checks ${{steps.pre-commit.outcome }}"
+          target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+            github.run_id }}"

--- a/.github/workflows/reusable-pre-commit-checks.yml
+++ b/.github/workflows/reusable-pre-commit-checks.yml
@@ -1,4 +1,4 @@
-name: Dependabot Auto-Merge
+name: Pre-Commit Checks
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-pre-commit-checks.yml
+++ b/.github/workflows/reusable-pre-commit-checks.yml
@@ -2,14 +2,6 @@ name: Pre-Commit Checks
 
 on:
   workflow_call:
-    inputs:
-      # Placeholder input: this workflow currently takes no real inputs, but
-      # `workflow_call` requires the `inputs` map to be present.
-      _placeholder:
-        description: "Unused. Reserved for future use; do not set."
-        required: false
-        type: string
-        default: ""
 
 permissions:
   contents: read

--- a/docs/reusable-pre-commit-checks.md
+++ b/docs/reusable-pre-commit-checks.md
@@ -1,0 +1,60 @@
+# Pre-Commit Checks
+
+Runs the repository's [`pre-commit`](https://pre-commit.com/) hooks against all files in CI. This is useful for enforcing linting, formatting, and other repository-defined checks on every pull request without relying on contributors to have a working local `pre-commit` install.
+
+The workflow uses [`uv`](https://docs.astral.sh/uv/) (via [`astral-sh/setup-uv`](https://github.com/astral-sh/setup-uv)) to install and run `pre-commit` with the [`pre-commit-uv`](https://github.com/tox-dev/pre-commit-uv) plugin, and [`asdf`](https://asdf-vm.com/) (via [`asdf-vm/actions`](https://github.com/asdf-vm/actions)) to provision any additional tools declared in a `.tool-versions` file at the repository root. Both the `pre-commit` environment and `asdf`-installed tools are cached between runs to keep execution fast.
+
+On completion, the workflow publishes a `Pre-Commit Checks` commit status to the head SHA via the [`update-status-check`](../.github/actions/update-status-check) action so the result is visible on the pull request even when the underlying job is skipped or re-run.
+
+## Usage
+
+Add the following workflow to your repository (suggested name: `.github/workflows/pull-request-precommit-checks.yml`):
+
+```yaml
+name: Pre-Commit Checks
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [main]
+
+jobs:
+  pre-commit:
+    name: Pre-Commit Checks
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pre-commit-checks.yml@ref
+```
+
+Be sure you replace `ref` with an appropriate ref to this repository.
+
+Your repository must contain a valid `.pre-commit-config.yaml` at the root. If additional CLI tooling is required by your hooks (e.g. `terraform`, `tflint`, `terragrunt`), declare it in a `.tool-versions` file at the repository root and `asdf` will install it before the hooks run.
+
+> [!CAUTION]
+> By default, we are not enforcing pre-commit as a required quality gate to merge PRs into _most_ repositories. This will change as we finish migrating to the new workflows and pre-commit runs in more places.
+>
+> If you need to enforce this on a particular repository in the meantime, reach out to an Organization Admin (generally via Slack) and have them add your repository to the [pre-commit-checks-validation](https://github.com/organizations/launchbynttdata/settings/rules/15529245) branch protection rule.
+
+To make this workflow required, visit your repository's settings and create a new Ruleset with a required status check pointing at `Pre-Commit Checks`.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `_placeholder` | `string` | No | `""` | Unused. Reserved for future use; do not set. |
+
+## Secrets
+
+This workflow does not consume any secrets.
+
+## Required Permissions
+
+The calling workflow must grant the following permissions:
+
+| Permission | Level | Reason |
+|------------|-------|--------|
+| `contents` | `read` | Check out the repository at the PR head. |
+| `pull-requests` | `read` | Read PR metadata when invoked from a `pull_request` event. |
+| `statuses` | `write` | Publish the `Pre-Commit Checks` commit status to the head SHA. |

--- a/docs/reusable-pre-commit-checks.md
+++ b/docs/reusable-pre-commit-checks.md
@@ -41,9 +41,7 @@ To make this workflow required, visit your repository's settings and create a ne
 
 ## Inputs
 
-| Input | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `_placeholder` | `string` | No | `""` | Unused. Reserved for future use; do not set. |
+This workflow does not have any inputs.
 
 ## Secrets
 


### PR DESCRIPTION
Perform a lift-and-shift of pre-commit actions to a reusable workflow that can be called by other repos. Additionally, cleans up a tag reference on actions/checkout by replacing the tag with a SHA.

We'll need to do some work to update the downstreams to consume pre-commit in this way, but for the most part that change will roll out through the auto-update system on the skeleton.