### PR TITLE
feat: add cache-rebuilding workflow to go along with pre-commit workflow

### DIFF
--- a/.github/workflows/push-rebuild-caches.yml
+++ b/.github/workflows/push-rebuild-caches.yml
@@ -1,0 +1,16 @@
+name: Rebuild Caches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .pre-commit-config.yaml
+      - .tool-versions
+  workflow_dispatch:
+
+jobs:
+  rebuild-caches:
+    name: Rebuild Caches
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-rebuild-caches.yml

--- a/.github/workflows/reusable-rebuild-caches.yml
+++ b/.github/workflows/reusable-rebuild-caches.yml
@@ -1,0 +1,68 @@
+name: Rebuild Caches
+on:
+  workflow_call:
+    inputs:
+      cache_precommit:
+        description: "Rebuild and persist the cache for pre-commit."
+        required: false
+        type: boolean
+        default: true
+      cache_asdf:
+        description: "Rebuild and persist the cache for ASDF tools."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild-caches:
+    name: Rebuild Caches
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+
+      - id: setup-python
+        name: Set up Python 3.14
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          python-version: 3.14
+
+      - id: install-tools
+        if: ${{ inputs.cache_precommit }}
+        name: Install Tools with uv
+        run: |
+          uv tool install pre-commit --with pre-commit-uv
+
+      - id: asdf-install
+        if: ${{ inputs.cache_asdf }}
+        name: Setup tools using asdf
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
+
+      - id: pre-commit
+        if: ${{ inputs.cache_precommit }}
+        name: Run pre-commit checks
+        run: uv run pre-commit install-hooks
+
+      - id: save-pre-commit-cache
+        if: ${{ inputs.cache_precommit }}
+        name: Save pre-commit cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - id: save-asdf-cache
+        if: ${{ inputs.cache_asdf }}
+        name: Save asdf cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: |
+            ~/.asdf/installs
+            ~/.asdf/plugins
+          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}

--- a/docs/reusable-rebuild-caches.md
+++ b/docs/reusable-rebuild-caches.md
@@ -1,0 +1,76 @@
+# Rebuild Caches
+
+Rebuilds and persists the GitHub Actions caches used by `pre-commit` and `asdf install` so that downstream pull request workflows (e.g. [Pre-Commit Checks](reusable-pre-commit-checks.md)) start with a primed cache and complete more quickly.
+
+This workflow is intended to run on `push` to your default branch. When it runs, it:
+
+- Installs `pre-commit` (via [`uv`](https://docs.astral.sh/uv/) and the [`pre-commit-uv`](https://github.com/tox-dev/pre-commit-uv) plugin), executes `pre-commit install-hooks` to populate hook environments, and saves `~/.cache/pre-commit` to the cache keyed on the hash of `.pre-commit-config.yaml`.
+- Installs all tools declared in `.tool-versions` via [`asdf`](https://asdf-vm.com/) and saves `~/.asdf/installs` and `~/.asdf/plugins` to the cache keyed on the hash of `.tool-versions`.
+
+Because the cache keys match those used by [`reusable-pre-commit-checks.yml`](../.github/workflows/reusable-pre-commit-checks.yml), pull request runs will find a cache hit until either `.pre-commit-config.yaml` or `.tool-versions` changes.
+
+## Usage
+
+Add the following workflow to your repository (suggested name: `.github/workflows/push-rebuild-caches.yml`):
+
+```yaml
+name: Rebuild Caches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .pre-commit-config.yaml
+      - .tool-versions
+  workflow_dispatch:
+
+jobs:
+  rebuild-caches:
+    name: Rebuild Caches
+    permissions:
+      contents: read
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-rebuild-caches.yml@ref
+```
+
+Be sure you replace `ref` with an appropriate ref to this repository.
+
+The `paths` filter ensures the workflow only runs when `.pre-commit-config.yaml` or `.tool-versions` actually changes — the cache keys are derived from the hashes of these files, so other pushes to `main` would just rebuild an identical cache.
+
+To rebuild only one of the two caches, set the other input to `false`:
+
+```yaml
+jobs:
+  rebuild-caches:
+    name: Rebuild Caches
+    permissions:
+      contents: read
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-rebuild-caches.yml@ref
+    with:
+      cache_precommit: true
+      cache_asdf: false
+```
+
+> [!TIP]
+> Pair this workflow with [Pre-Commit Checks](reusable-pre-commit-checks.md) on pull requests. The PR workflow will restore the caches produced here, avoiding the cost of reinstalling hook environments and `asdf` tools on every PR run.
+
+> [!NOTE]
+> GitHub Actions caches are scoped by branch. Running this workflow on your default branch makes the resulting caches available to all PR branches (which fall back to the default branch's cache on a miss). Running it on a feature branch will only benefit that branch.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `cache_precommit` | `boolean` | No | `true` | Rebuild and persist the cache for `pre-commit` hook environments (`~/.cache/pre-commit`). |
+| `cache_asdf` | `boolean` | No | `true` | Rebuild and persist the cache for `asdf`-installed tools (`~/.asdf/installs` and `~/.asdf/plugins`). |
+
+## Secrets
+
+This workflow does not consume any secrets.
+
+## Required Permissions
+
+The calling workflow must grant the following permissions:
+
+| Permission | Level | Reason |
+|------------|-------|--------|
+| `contents` | `read` | Check out the repository so that `.pre-commit-config.yaml` and `.tool-versions` are available. |


### PR DESCRIPTION
Goes along with #89, this rebuilds the caches on a given repo for asdf and pre-commit.

This is intended to be run on merge to main, so that the cache applies to main and any PRs that are created from main, decreasing actions runtime. Since caches don't persist forever, I've included `workflow_dispatch` as a recommended event, so that if necessary the caches can be rebuilt manually.