### PR TITLE
perf: cache Terraform provider plugins in terraform-check

### DIFF
--- a/.github/workflows/reusable-terraform-check.yml
+++ b/.github/workflows/reusable-terraform-check.yml
@@ -157,6 +157,28 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
 
+      - id: tf-plugin-cache-dir
+        name: Configure Terraform plugin cache directory
+        # Terraform silently ignores the plugin cache if the directory does not
+        # already exist, so create it before any init runs.
+        shell: bash
+        run: |
+          echo "TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache" >> "$GITHUB_ENV"
+          mkdir -p "$HOME/.terraform.d/plugin-cache"
+
+      - id: tf-plugin-cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        # Provider downloads dominate the cost of `terraform init`, and the
+        # Makefile inits the root module and every example separately, so each
+        # one currently re-downloads the same providers. A single shared cache
+        # serves all of them within a run and persists across runs.
+        name: Cache Terraform provider plugins
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: ${{ runner.os }}-tf-plugins-${{ hashFiles('**/versions.tf') }}
+          restore-keys: |
+            ${{ runner.os }}-tf-plugins-
+
       - id: configure
         name: Setup Repository for Checks
         # Ensure the 'repo' tool is installed, set up git to make the Makefile happy, and then configure to clone LCAF.
@@ -229,6 +251,28 @@ jobs:
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-tool-versions-${{ hashFiles('.tool-versions') }}
+
+      - id: tf-plugin-cache-dir
+        name: Configure Terraform plugin cache directory
+        # Terraform silently ignores the plugin cache if the directory does not
+        # already exist, so create it before any init runs.
+        shell: bash
+        run: |
+          echo "TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache" >> "$GITHUB_ENV"
+          mkdir -p "$HOME/.terraform.d/plugin-cache"
+
+      - id: tf-plugin-cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        # Provider downloads dominate the cost of `terraform init`, and the
+        # Makefile inits the root module and every example separately, so each
+        # one currently re-downloads the same providers. A single shared cache
+        # serves all of them within a run and persists across runs.
+        name: Cache Terraform provider plugins
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: ${{ runner.os }}-tf-plugins-${{ hashFiles('**/versions.tf') }}
+          restore-keys: |
+            ${{ runner.os }}-tf-plugins-
 
       - id: configure
         name: Setup Repository for Checks


### PR DESCRIPTION
## Summary

Adds a shared Terraform provider plugin cache to both jobs in `reusable-terraform-check.yml` that run `terraform init` (`lint` and `tests`).

## Why

`tfmodule/init` in the module Makefile initializes the root module **and every example directory separately**. Without a shared plugin cache each of those directories downloads the same providers from scratch, so a module with a root plus two examples pulls azurerm or aws three times per run — repeated across every PR in ~90 skeleton-managed repos.

Setting `TF_PLUGIN_CACHE_DIR` collapses that to one download per run, and caching the directory across runs removes it almost entirely.

## Notes

- The directory is created explicitly, because **Terraform silently ignores the plugin cache when the directory does not already exist** — without the `mkdir` this change would be a no-op that looks correct.
- `TF_PLUGIN_CACHE_DIR` is exported via `$GITHUB_ENV` rather than a job-level `env:` so the path can be derived from `$HOME` instead of hardcoding `/home/runner`.
- Pinned to the same `actions/cache` commit already used by this workflow for the asdf tool cache, so there is no new action version to review.
- Cache key is the hash of `**/versions.tf` with a `restore-keys` prefix fallback, so a provider constraint change gets a fresh entry while still warm-starting from the previous one.

## Independent value

This stands on its own as a speedup for what CI already does. It also happens to be the prerequisite that makes an upcoming `required_version` floor check cheap — that check inits a second time with an older Terraform, and provider binaries are independent of Terraform core version, so it reuses these same cached providers rather than re-downloading. See `launch-terraform-skeleton#38`.

Generated with Cursor Agent (Opus 5)

Made with [Cursor](https://cursor.com)