### PR TITLE
feat: enforce Terraform version floor in CI

### DIFF
--- a/.github/workflows/reusable-terraform-check.yml
+++ b/.github/workflows/reusable-terraform-check.yml
@@ -195,6 +195,22 @@ jobs:
         run: |
           make lint
 
+      - id: version-floor
+        name: "Verify declared Terraform version floor"
+        # Confirms required_version names a version the module can actually be
+        # loaded with, by initializing it with the oldest version the constraint
+        # admits. The guard ships via launch-terraform-skeleton, so it is absent
+        # until a repo has picked up that update; skip loudly rather than fail,
+        # and rather than pass silently.
+        shell: bash
+        run: |
+          guard=".github/scripts/check-terraform-version-floor.sh"
+          if [[ ! -f "${guard}" ]]; then
+            echo "::notice title=Version floor check skipped::${guard} is not present in this repository yet. It arrives with the next launch-terraform-skeleton update."
+            exit 0
+          fi
+          make tfmodule/check-version-floor
+
       - id: update-lint-status
         name: "Update Terraform Lint status"
         if: always() && steps.lint.outcome != 'skipped'

--- a/.github/workflows/reusable-terraform-check.yml
+++ b/.github/workflows/reusable-terraform-check.yml
@@ -195,7 +195,35 @@ jobs:
         run: |
           make lint
 
-      - id: version-floor
+      - id: version_floor_resolve
+        name: "Resolve declared Terraform version floor"
+        # Resolved before the check runs so the floor's toolchain can be cached
+        # by version. Emits an empty value in the two cases where there is
+        # nothing to cache -- the guard has not propagated to this repo yet, or
+        # the constraint declares no lower bound -- leaving the real diagnostic
+        # to the check step rather than failing here with something cryptic.
+        shell: bash
+        run: |
+          guard=".github/scripts/check-terraform-version-floor.sh"
+          version=""
+          if [[ -f "${guard}" ]]; then
+            version="$(bash "${guard}" --print-floor 2>/dev/null || true)"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - id: version_floor_cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        # The asdf tool cache is keyed on .tool-versions and only saved on a
+        # miss, so a Terraform installed after that restore is never persisted.
+        # This entry is keyed on the resolved floor instead, so the floor's
+        # binary is downloaded once per version rather than on every run.
+        if: steps.version_floor_resolve.outputs.version != ''
+        name: Cache floor-version Terraform
+        with:
+          path: ~/.asdf/installs/terraform/${{ steps.version_floor_resolve.outputs.version }}
+          key: ${{ runner.os }}-tf-floor-${{ steps.version_floor_resolve.outputs.version }}
+
+      - id: version_floor
         name: "Verify declared Terraform version floor"
         # Confirms required_version names a version the module can actually be
         # loaded with, by initializing it with the oldest version the constraint
@@ -213,13 +241,17 @@ jobs:
 
       - id: update-lint-status
         name: "Update Terraform Lint status"
+        # Reflects the version-floor check as well as make lint, so this status
+        # cannot report success while the job is red.
         if: always() && steps.lint.outcome != 'skipped'
         uses: launchbynttdata/launch-workflows/.github/actions/update-status-check@0.15.0
         with:
           check_name: "Terraform Lint"
-          status: ${{ steps.lint.outcome == 'success' && 'success' || steps.lint.outcome
-            == 'failure' && 'failure' || 'error' }}
-          description: "Terraform lint ${{ steps.lint.outcome }}"
+          status: ${{ (steps.lint.outcome == 'success' && steps.version_floor.outcome
+            != 'failure') && 'success' || (steps.lint.outcome == 'failure' || steps.version_floor.outcome
+            == 'failure') && 'failure' || 'error' }}
+          description: "Terraform lint ${{ steps.lint.outcome }}, version floor ${{
+            steps.version_floor.outcome }}"
           target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
             github.run_id }}"
 


### PR DESCRIPTION
## Summary

Runs the Terraform version-floor guard in `reusable-terraform-check.yml`, after `make lint`.

**Depends on `launch-terraform-skeleton#38`**, which ships the guard itself. Safe to merge before that propagates — see below.

## Why

Modules across the fleet declare a `required_version` floor lower than their configuration actually supports. A consumer on a version *inside* the declared range satisfies the constraint and then hits a hard parse error, so the constraint misleads rather than protects.

Measured across all 322 `tf-*-module_*` repositories: of the 93 copier-converted ones, **7 declared a floor their own configuration rejects** — confirmed by loading each with the oldest Terraform its constraint permitted and watching Terraform refuse it. Fix PRs for all seven are open, so this should arrive green.

## Rollout safety

The guard lives at `.github/scripts/check-terraform-version-floor.sh` and arrives via the skeleton update, so it will not exist in a repository until that propagates. The step therefore skips when the script is absent.

It skips **loudly** — emitting a `::notice` — rather than passing silently. A check that quietly no-ops is worse than no check, since it reads as green without having verified anything. The notice makes the transitional state visible in the job summary and gives it an obvious end condition.

## Approach

Deliberately not a table of "which feature needs which Terraform version" — that list grows indefinitely and silently passes anything unlisted. The guard resolves the oldest version the constraint admits and asks Terraform to load the module with it, so it stays correct as new language features ship without anyone maintaining it.

## Cost

Near zero once `launch-workflows#93` is in: provider downloads dominate `terraform init`, and provider binaries are independent of Terraform core version, so this second init reuses the same cached providers. Without that cache this would double provider downloads, so #93 should merge first.

Generated with Cursor Agent (Opus 5)

Made with [Cursor](https://cursor.com)